### PR TITLE
Bp 2025 07 enhancements

### DIFF
--- a/fhirpath_py_server/fhirpath.py
+++ b/fhirpath_py_server/fhirpath.py
@@ -24,7 +24,7 @@ def collect_trace_data():
 def evaluate_with_trace(model, data, expression, variables=None):
     """Evaluate FHIRPath expression with trace collection"""
     trace_callback, trace_data = collect_trace_data()
-    options = { "trace_callback": trace_callback, "return_raw_data": True }
+    options = { "traceFn": trace_callback, "returnRawData": True }
     result = evaluate(data, expression, variables or {}, model=model, options=options)
     
     # Debug: print what we got
@@ -224,7 +224,7 @@ def create_parameters(
     resource_type_path = f"{resource_type}." if resource_type else ""
 
     if context:
-        options = {"return_raw_data": True}
+        options = {"returnRawData": True}
         context_nodes = evaluate(resource, context, variables or {}, model=model, options=options)
         if not isinstance(context_nodes, list):
             context_nodes = [context_nodes]

--- a/fhirpath_py_server/fhirpath.py
+++ b/fhirpath_py_server/fhirpath.py
@@ -1,5 +1,8 @@
 from aiohttp import web
 from fhirpathpy import evaluate, __version__ as fhirpathpy_version
+import fhirpathpy.engine.nodes as nodes
+import json
+from decimal import Decimal
 
 
 def parse_request_data(data):
@@ -32,8 +35,154 @@ def parse_request_data(data):
 def node_results_to_types(node_results):
     result = []
     for result_item in node_results:
-        item_type = type(result_item).__name__
-        result.append({"name": item_type, "valueString": result_item})
+        if isinstance(result_item, nodes.ResourceNode):
+            type_info = result_item.get_type_info()
+            val = {
+                "extension": [{"url": "http://fhir.forms-lab.com/StructureDefinition/resource-path", "valueString": result_item.propName}],
+                "name": result_item.path if result_item.path else type_info.name if type_info and hasattr(type_info, "name") else "Unknown",
+            }
+            result.append(val)
+            # convert all the known extension value types to use the actual property https://hl7.org/fhir/R4/extensibility.html
+            match val["name"]:
+                # primitive types
+                case "base64binary":
+                    val["valueBase64Binary"] = result_item.data
+                case "boolean":
+                    val["valueBoolean"] = result_item.data
+                case "canonical":
+                    val["valueCanonical"] = result_item.data
+                case "code":
+                    val["valueCode"] = result_item.data
+                case "date":
+                    val["valueDate"] = result_item.data
+                case "dateTime":
+                    val["valueDateTime"] = result_item.data
+                case "decimal":
+                    val["valueDecimal"] = result_item.data
+                case "id":
+                    val["valueId"] = result_item.data
+                case "instant":
+                    val["valueInstant"] = result_item.data
+                case "integer":
+                    val["valueInteger"] = result_item.data
+                case "markdown":
+                    val["valueMarkdown"] = result_item.data
+                case "oid":
+                    val["valueOid"] = result_item.data
+                case "positiveInt":
+                    val["valuePositiveInt"] = result_item.data
+                case "string":
+                    val["valueString"] = result_item.data
+                case "time":
+                    val["valueTime"] = result_item.data
+                case "unsignedInt":
+                    val["valueUnsignedInt"] = result_item.data
+                case "uri":
+                    val["valueUri"] = result_item.data
+                case "url":
+                    val["valueUrl"] = result_item.data
+                case "uuid":
+                    val["valueUuid"] = result_item.data
+
+                # complex types
+                case "Address":
+                    val["valueAddress"] = result_item.data
+                case "Annotation":
+                    val["valueAnnotation"] = result_item.data
+                case "Attachment":
+                    val["valueAttachment"] = result_item.data
+                case "CodeableConcept":
+                    val["valueCodeableConcept"] = result_item.data
+                case "Coding":
+                    val["valueCoding"] = result_item.data
+                case "ContactPoint":
+                    val["valueContactPoint"] = result_item.data
+                case "HumanName":
+                    val["valueHumanName"] = result_item.data
+                case "Identifier":
+                    val["valueIdentifier"] = result_item.data
+                case "Money":
+                    val["valueMoney"] = result_item.data
+                case "Period":
+                    val["valuePeriod"] = result_item.data
+                case "Quantity":
+                    val["valueQuantity"] = result_item.data
+                case "Range":
+                    val["valueRange"] = result_item.data
+                case "Ratio":
+                    val["valueRatio"] = result_item.data
+                case "Reference":
+                    val["valueReference"] = result_item.data
+                case "SampledData":
+                    val["valueSampledData"] = result_item.data
+                case "Signature":
+                    val["valueSignature"] = result_item.data
+                case "Timing":
+                    val["valueTiming"] = result_item.data
+                case "ContactDetail":
+                    val["valueContactDetail"] = result_item.data
+                case "Contributor":
+                    val["valueContributor"] = result_item.data
+                case "DataRequirement":
+                    val["valueDataRequirement"] = result_item.data
+                case "Expression":
+                    val["valueExpression"] = result_item.data
+                case "ParameterDefinition":
+                    val["valueParameterDefinition"] = result_item.data
+                case "RelatedArtifact":
+                    val["valueRelatedArtifact"] = result_item.data
+                case "TriggerDefinition":
+                    val["valueTriggerDefinition"] = result_item.data
+                case "UsageContext":
+                    val["valueUsageContext"] = result_item.data
+                case "Dosage":
+                    val["valueDosage"] = result_item.data
+                case "Meta":
+                    val["valueMeta"] = result_item.data
+
+                # everything else (fallback to raw json in extension)
+                case _:
+                    extVal = { 
+                       "url": "http://fhir.forms-lab.com/StructureDefinition/json-value", 
+                       "valueString": result_item.toJSON()
+                    }
+                    val["extension"].append(extVal)
+        elif isinstance(result_item, Decimal):
+            result.append({
+                "name": "Decimal",
+                "valueDecimal": float(result_item),
+            })
+        elif isinstance(result_item, nodes.FP_Quantity):
+            result.append({
+                "name": "Quantity",
+                "valueQuantity": {
+                    "value": float(result_item.value),
+                    "unit": result_item.unit,
+                }
+            })
+        elif isinstance(result_item, nodes.FP_DateTime):
+            result.append({
+                "name": "DateTime",
+                "valueDateTime": result_item.asStr,
+            })
+        elif isinstance(result_item, nodes.FP_Time):
+            result.append({
+                "name": "Time",
+                "valueTime": result_item.asStr,
+            })
+        else:
+            if type(result_item).__name__ == "int":
+                # case "int": # from raw fhirpath content, not FHIR data
+                #    val["valueInteger"] = result_item.data
+                result.append({
+                    "name": "Integer",
+                    "valueInteger": result_item 
+                })
+            else:
+                result.append({
+                    "name": type(result_item).__name__,
+                    "valueString": json.dumps(result_item), 
+                })
 
     return result
 

--- a/fhirpath_py_server/main.py
+++ b/fhirpath_py_server/main.py
@@ -1,13 +1,15 @@
 import aiohttp_cors
 from aiohttp import web
 
-from fhirpath import handle_fhirpath
+from fhirpath import handle_fhirpath_r4, handle_fhirpath_r5
 
 
 app = web.Application()
 
 resource_fhirpath = app.router.add_resource("/fhir/$fhirpath")
-route = resource_fhirpath.add_route("POST", handle_fhirpath)
+resource_fhirpathR5 = app.router.add_resource("/fhir/$fhirpath-r5")
+route = resource_fhirpath.add_route("POST", handle_fhirpath_r4)
+routeR5 = resource_fhirpathR5.add_route("POST", handle_fhirpath_r5)
 
 cors = aiohttp_cors.setup(app)
 allowed_domains = [
@@ -29,7 +31,7 @@ cors_options = {
 }
 
 cors.add(resource_fhirpath, cors_options)
-
+cors.add(resource_fhirpathR5, cors_options)
 
 if __name__ == "__main__":
     web.run_app(app, port=8081)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fhirpath-py-server"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["beda.software <info@beda.software>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ packages = [{include = "fhirpath_py_server"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "^3.9.3"
-fhirpathpy = "^1.0.0"
+fhirpathpy = "^2.1.0"
 python-dateutil = "^2.8.2"
 aiohttp-cors = "^0.7.0"
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `fhirpath_py_server` module, focusing on traceability, data type handling, and error management. The changes improve the server's ability to evaluate FHIRPath expressions with detailed trace data, handle diverse FHIR data types, and provide robust error responses.

### Enhancements to FHIRPath evaluation:

- **Trace collection for FHIRPath evaluations**: Added a new `evaluate_with_trace` function that collects trace data during FHIRPath expression evaluation, enabling better debugging and insight into the evaluation process.
- **Trace integration in `create_parameters`**: Updated the `create_parameters` function to include trace data in the results, providing structured trace information alongside evaluation results. [[1]](diffhunk://#diff-82634660d4952246dfadb841bc250dfa4c636cdfb74c5ba0d1921b669e3a09cdL50-R261) [[2]](diffhunk://#diff-82634660d4952246dfadb841bc250dfa4c636cdfb74c5ba0d1921b669e3a09cdL75-R294)

### Improved data type handling:

- **Enhanced `node_results_to_types` function**: Extended the function to support a wide range of FHIR primitive and complex data types, ensuring proper serialization and handling of FHIRPath evaluation results. Added fallback logic for unknown types to include raw JSON data in extensions.

### Error handling improvements:

- **Robust error responses in `handle_fhirpath`**: Added exception handling for `ValueError`, `KeyError`, and general exceptions in the `handle_fhirpath` function, returning appropriate HTTP status codes and detailed OperationOutcome resources for better client feedback.

Along with the other PR for the fhirpath.py engine https://github.com/HL7/fhirpath.js/pull/174 this resolves all open issues in this project (integrating with the lab)

No current issues, but we should log them:
* provide the AST that is processed (needs to be specified - but is final in the lab)
* provide a debug trace for the results of an expression evaluation (needs to be specified)